### PR TITLE
ci: Use semantic-release version with v0.x support

### DIFF
--- a/.github/workflows/semantic-release.yaml
+++ b/.github/workflows/semantic-release.yaml
@@ -18,7 +18,7 @@ jobs:
 
       - name: Run go-semantic-release
         id: semrel
-        uses: go-semantic-release/action@v1.1.0
+        uses: go-semantic-release/action@v1.2.0
         with:
           github-token: ${{ secrets.GH_PAT_TOKEN }}
           allow-initial-deployment-versions: true


### PR DESCRIPTION
Updates the semantic-release action to provide the
allow-initial-deployment-versions input.