### PR TITLE
fix(container image): Use GitHub Personal Action Token to ush image

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -21,7 +21,7 @@ jobs:
           go-version: 1.14.x
 
       - name: Login to GitHub Package Registry
-        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u "${{ github.actor }}" --password-stdin
+        run: echo "${{ secrets.GH_PAT_TOKEN }}" | docker login ghcr.io -u "${{ github.actor }}" --password-stdin
 
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v1


### PR DESCRIPTION
ghcr.io mandates using a PAT to push the image. Fix for what went wrong in #20