### PR TITLE
chore(ci): enable dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,22 @@
+
+version: 2
+updates:
+
+  # Update Go modules
+  - package-ecosystem: "gomod"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    commit-message:
+      prefix: "feat(deps): "
+      prefix-development: "chore(deps): "
+    open-pull-requests-limit: 20
+
+  # Maintain dependencies for GitHub Actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    commit-message:
+      prefix: "chore(ci): "
+    open-pull-requests-limit: 10


### PR DESCRIPTION
Enable dependabot for github-actions and gomod ecosystems.