### PR TITLE
fix: drop darwin support

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -10,7 +10,6 @@ builds:
   - "-X 'github.com/radiorabe/virtual-saemubox/cmd.date={{.Date}}'"
 archives:
 - replacements:
-    darwin: Darwin
     linux: Linux
     windows: Windows
     386: i386


### PR DESCRIPTION
Darwin support is currently failing the build and we're dropping it
as part of the beginning of phasing this utility out.